### PR TITLE
Fix sharing for modified official modpacks

### DIFF
--- a/subprocess/src/main/java/net/creeperhost/creeperlauncher/Constants.java
+++ b/subprocess/src/main/java/net/creeperhost/creeperlauncher/Constants.java
@@ -77,6 +77,7 @@ public class Constants {
     public static final OkHttpClient OK_HTTP_CLIENT = new OkHttpClient.Builder()
             .connectTimeout(5, TimeUnit.MINUTES)
             .readTimeout(5, TimeUnit.MINUTES)
+            .writeTimeout(5, TimeUnit.MINUTES)
             .connectionPool(new ConnectionPool())
             .cookieJar(new SimpleCookieJar())
             .addInterceptor(new ThrottlerInterceptor())

--- a/subprocess/src/main/java/net/creeperhost/creeperlauncher/api/handlers/instances/InstanceInstallModHandler.java
+++ b/subprocess/src/main/java/net/creeperhost/creeperlauncher/api/handlers/instances/InstanceInstallModHandler.java
@@ -83,6 +83,7 @@ public class InstanceInstallModHandler implements IMessageHandler<InstanceInstal
         ArrayList<DownloadTask> downloadTasks = new ArrayList<>();
 
         for(Mod.Version ver: filesToDownload) {
+            instance.versionManifest.getFiles().add(ver.getModpackFile());
             DownloadableFile downloadableFile = ver.getDownloadableFile(instance);
             DownloadTask downloadTask = new DownloadTask(downloadableFile, downloadableFile.getPath(), new ProgressTracker(downloadableFile));
             fileTracker.put(downloadableFile, (ProgressTracker) downloadTask.getWatcher());
@@ -139,6 +140,7 @@ public class InstanceInstallModHandler implements IMessageHandler<InstanceInstal
               try {
                   instance.setModified(true);
                   instance.saveJson();
+                  instance.saveVersion();
               } catch(Exception ignored) {
                   LOGGER.error("Failed to update instance json for {}", instance.getName());
               }

--- a/subprocess/src/main/java/net/creeperhost/creeperlauncher/mod/Mod.java
+++ b/subprocess/src/main/java/net/creeperhost/creeperlauncher/mod/Mod.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonSyntaxException;
 import net.creeperhost.creeperlauncher.Constants;
 import net.creeperhost.creeperlauncher.api.DownloadableFile;
 import net.creeperhost.creeperlauncher.api.handlers.ModFile;
+import net.creeperhost.creeperlauncher.data.modpack.ModpackVersionManifest;
 import net.creeperhost.creeperlauncher.pack.IPack;
 import net.creeperhost.creeperlauncher.util.GsonUtils;
 import net.creeperhost.creeperlauncher.util.LoaderTarget;
@@ -48,6 +49,10 @@ public class Mod {
             }
 
             return new DownloadableFile(instance.getDir().resolve(path).resolve(name), url, hashes, size, id, name, type);
+        }
+        
+        public ModpackVersionManifest.ModpackFile getModpackFile(){
+            return new ModpackVersionManifest.ModpackFile(-1, path, name, url, HashCode.fromString(sha1), size, type);
         }
 
         public List<Version> getDependencies(List<ModFile> existingFiles, List<Version> fileCandidates, LoaderTarget gameTarget, LoaderTarget loaderTarget) {

--- a/subprocess/src/main/java/net/creeperhost/creeperlauncher/pack/LocalInstance.java
+++ b/subprocess/src/main/java/net/creeperhost/creeperlauncher/pack/LocalInstance.java
@@ -428,6 +428,10 @@ public class LocalInstance implements IPack
         }
         return true;
     }
+    
+    public void saveVersion() throws IOException{
+        JsonUtils.write(ModpackVersionManifest.GSON, path.resolve("version.json"), versionManifest, ModpackVersionManifest.class);
+    }
 
     @Override
     public long getId()


### PR DESCRIPTION
Closes #660 and closes #661

This might break when updating a modpack to another version.

Tested it to share a modpack (FTB direwolf20 1.18) with added mods and config files.
The config files will be uploaded to the transfer.sh service, but the mods will be fetched from curseforge instead.