### PR TITLE
Show Import new packs button if no modpacks are installed

### DIFF
--- a/src/views/Library.vue
+++ b/src/views/Library.vue
@@ -52,6 +52,9 @@
           <router-link to="/discover">
             <ftb-button color="primary" class="py-2 px-6 mx-2">Discover</ftb-button>
           </router-link>
+          <ftb-button color="primary" class="py-2 px-6 mx-2 flex items-center" @click="showImport = true">
+            Import
+          </ftb-button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR adds the green import button to the empty-modpacks-oh-no-screen.
![image](https://user-images.githubusercontent.com/1916723/184925710-3e9ac39e-13b7-4323-a312-a9295fdebab9.png)

If one or more modpacks are installed, the following Import button is already shown (but only if modpacks are installed)
![image](https://user-images.githubusercontent.com/1916723/184925935-47b19d04-fb09-4f9e-a841-b6514ff50b72.png)
