### PR TITLE
Add option to launch with a shell

### DIFF
--- a/src/components/templates/modpack/ModpackSettings.vue
+++ b/src/components/templates/modpack/ModpackSettings.vue
@@ -110,6 +110,14 @@
       class="mb-4"
     />
 
+    <ftb-input
+      label="Shell"
+      :value="localInstance.shellArgs"
+      v-model="localInstance.shellArgs"
+      @blur="saveSettings"
+      class="mb-8"
+    />
+
     <p class="text-lg font-bold mb-4">Actions</p>
 
     <div class="buttons flex flex-1">

--- a/src/modules/modpacks/actions.ts
+++ b/src/modules/modpacks/actions.ts
@@ -300,6 +300,7 @@ export const actions: ActionTree<ModpackState, RootState> = {
               width: instance.width,
               height: instance.height,
               cloudSaves: instance.cloudSaves,
+              shellArgs: instance.shellArgs,
             },
           },
           callback: async (msg: any) => {

--- a/src/modules/modpacks/types.ts
+++ b/src/modules/modpacks/types.ts
@@ -53,6 +53,7 @@ export interface Instance {
   modLoader: string;
   embeddedJre: boolean;
   totalPlayTime: number;
+  shellArgs: string;
 }
 
 export interface Art {

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -35,6 +35,7 @@ export const state: SettingsState = {
     proxyHost: '',
     proxyPassword: '',
     proxyUser: '',
+    shellArgs: '',
   },
   error: false,
   hardware: {

--- a/src/modules/settings/mutations.ts
+++ b/src/modules/settings/mutations.ts
@@ -30,6 +30,7 @@ const defaultSettings: Settings = {
   proxyHost: '',
   proxyPassword: '',
   proxyUser: '',
+  shellArgs: '',
 };
 
 export const mutations: MutationTree<SettingsState> = {

--- a/src/modules/settings/types.ts
+++ b/src/modules/settings/types.ts
@@ -30,6 +30,8 @@ export interface Settings {
   proxyUser: string;
   proxyPassword: string;
   proxyType: 'http' | 'sock5' | 'none';
+
+  shellArgs: string;
 }
 
 export interface Hardware {

--- a/src/views/Settings/InstanceSettings.vue
+++ b/src/views/Settings/InstanceSettings.vue
@@ -66,6 +66,13 @@
       >Changing your instance location with instances installed will cause your instances to be moved to the new
       location automatically.</small
     >
+
+    <ftb-input
+      label="Shell"
+      :value="localSettings.shellArgs"
+      v-model="localSettings.shellArgs"
+      @blur="saveMutated"
+    />
   </div>
 </template>
 

--- a/subprocess/src/main/java/net/creeperhost/creeperlauncher/api/handlers/instances/InstanceConfigureHandler.java
+++ b/subprocess/src/main/java/net/creeperhost/creeperlauncher/api/handlers/instances/InstanceConfigureHandler.java
@@ -59,6 +59,9 @@ public class InstanceConfigureHandler implements IMessageHandler<InstanceConfigu
                             instance.jrePath = jreLocation;
                         }
                         break;
+                    case "shellargs":
+                        instance.shellArgs = setting.getValue();
+                        break;
                 }
             }
             instance.saveJson();

--- a/subprocess/src/main/java/net/creeperhost/creeperlauncher/pack/InstanceLauncher.java
+++ b/subprocess/src/main/java/net/creeperhost/creeperlauncher/pack/InstanceLauncher.java
@@ -450,6 +450,7 @@ public class InstanceLauncher {
                     .collect(Collectors.toList());
 
             List<String> command = new ArrayList<>(jvmArgs.size() + progArgs.size() + 2);
+            command.addAll(context.shellArgs);
             command.add(javaExecutable.toAbsolutePath().toString());
             command.addAll(jvmArgs);
             command.addAll(context.extraJVMArgs);
@@ -685,6 +686,7 @@ public class InstanceLauncher {
 
         public final List<String> extraJVMArgs = new ArrayList<>();
         public final List<String> extraProgramArgs = new ArrayList<>();
+        public final List<String> shellArgs = new ArrayList<>();
     }
 
     public enum Phase {

--- a/subprocess/src/main/java/net/creeperhost/creeperlauncher/pack/LocalInstance.java
+++ b/subprocess/src/main/java/net/creeperhost/creeperlauncher/pack/LocalInstance.java
@@ -92,6 +92,7 @@ public class LocalInstance implements IPack
     public boolean hasInstMods = false;
     public boolean installComplete = true;
     public byte packType;
+    public String shellArgs = Settings.settings.getOrDefault("shellArgs", "");
 
     /**
      * The current play time in millis.
@@ -213,6 +214,7 @@ public class LocalInstance implements IPack
             }
             this.totalPlayTime = jsonOutput.totalPlayTime;
             this.lastPlayed = jsonOutput.lastPlayed;
+            this.shellArgs = jsonOutput.shellArgs;
         }
     }
 
@@ -300,6 +302,8 @@ public class LocalInstance implements IPack
                 }
             }
             ctx.extraJVMArgs.addAll(jvmArgs);
+
+            ctx.shellArgs.addAll(MiscUtils.splitCommand(shellArgs));
         });
 
         if (!Constants.S3_SECRET.isEmpty() && !Constants.S3_KEY.isEmpty() && !Constants.S3_HOST.isEmpty() && !Constants.S3_BUCKET.isEmpty()) {


### PR DESCRIPTION
The PR adds an option to both the global and modpack settings to launch the JVM with a shell such as prime-run (#469) or MangoHud.

Closes #469 and closes #210