### PR TITLE
Fixed typo in version selection

### DIFF
--- a/src/components/organisms/modals/InstallModal.vue
+++ b/src/components/organisms/modals/InstallModal.vue
@@ -5,7 +5,7 @@
 
     <selection
       @selected="(e) => (version = !e ? null : e.id)"
-      placeholder="Selection version"
+      placeholder="Select version"
       :inheritedSelection="versionOptions[0]"
       :options="versionOptions"
     />


### PR DESCRIPTION
Just stumbled upon this, while installing a pack