### PR TITLE
Fix file selection

### DIFF
--- a/src/utils/interface/overwolf.ts
+++ b/src/utils/interface/overwolf.ts
@@ -222,7 +222,7 @@ const Overwolf: ElectronOverwolfInterface = {
     selectFileDialog(cb) {
       overwolf.utils.openFilePicker('', (resp: any) => {
         if (resp && resp.status === 'success') {
-          cb(resp.path);
+          cb(resp.file);
         }
       });
     },


### PR DESCRIPTION
The `path` property does not exist, the `file` property should be used instead

![immagine](https://github.com/FTBTeam/FTB-App/assets/17544193/12e8cbfd-7585-4690-8a3c-96d4940f7c76)
