### PR TITLE
fix: pin webpack to current patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "vue-class-component": "^7.2.3",
     "vue-cli-plugin-electron-builder": "^2.1.1",
     "vue-property-decorator": "^9.1.2",
-    "vue-template-compiler": "^2.6.11"
+    "vue-template-compiler": "^2.6.11",
+    "webpack": "4.46.0"
   },
   "pnpm": {
     "patchedDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ devDependencies:
   vue-template-compiler:
     specifier: ^2.6.11
     version: 2.7.14
+  webpack:
+    specifier: 4.46.0
+    version: 4.46.0(patch_hash=5tqvhjaav36iaibwqtacb3tnim)
 
 packages:
 


### PR DESCRIPTION
If not, it tried to use latest webpack when a dep required it.