### PR TITLE
Fixed megabyte calculation in valueAsByteReadable()

### DIFF
--- a/src/components/core/modpack/components/RamSlider.vue
+++ b/src/components/core/modpack/components/RamSlider.vue
@@ -101,7 +101,7 @@ export default class RamSlider extends Vue {
   }
   
   get valueAsByteReadable() {
-    return prettyByteFormat(Math.floor(parseInt(this.value.toString()) * 1024 * 1000));
+    return prettyByteFormat(Math.floor(parseInt(this.value.toString()) * 1024 * 1024));
   }
   
   get valueAsPercentage() {

--- a/src/components/core/modpack/components/RamSlider.vue
+++ b/src/components/core/modpack/components/RamSlider.vue
@@ -101,7 +101,8 @@ export default class RamSlider extends Vue {
   }
   
   get valueAsByteReadable() {
-    return prettyByteFormat(Math.floor(parseInt(this.value.toString()) * 1024 * 1024));
+    const megabyteSize = 1024 * 1024;
+    return prettyByteFormat(Math.floor(parseInt(this.value.toString()) * megabyteSize));
   }
   
   get valueAsPercentage() {


### PR DESCRIPTION
The previous code used the calculation 1024 * 1000 as the size of a megabyte. I fixed this to be 1024 * 1024 and put it in a named constant for easier code readability.