### PR TITLE
Fix: Ram values on modpack settings page

### DIFF
--- a/src/components/core/modpack/components/RamSlider.vue
+++ b/src/components/core/modpack/components/RamSlider.vue
@@ -46,7 +46,7 @@ import {Component, Emit, Prop, Vue} from 'vue-property-decorator';
 import {SettingsState} from '@/modules/settings/types';
 import {State} from 'vuex-class';
 import UiButton from '@/components/core/ui/UiButton.vue';
-import {prettyByteFormat} from '@/utils';
+import {prettyByteFormat, megabyteSize} from '@/utils';
 import UiToggle from '@/components/core/ui/UiToggle.vue';
 
 @Component({
@@ -56,7 +56,7 @@ export default class RamSlider extends Vue {
   @State('settings') public settingsState!: SettingsState;
   
   @Prop({default: 0}) min!: number;
-  @Prop({default: 0}) value!: number | string;
+  @Prop({default: 0}) value!: number | string; // stored in megabytes.
   @Emit() input(value: number) {}
   @Emit() change(value: number) {}
   
@@ -101,7 +101,6 @@ export default class RamSlider extends Vue {
   }
   
   get valueAsByteReadable() {
-    const megabyteSize = 1024 * 1024;
     return prettyByteFormat(Math.floor(parseInt(this.value.toString()) * megabyteSize));
   }
   

--- a/src/components/templates/modpack/ModpackSettings.vue
+++ b/src/components/templates/modpack/ModpackSettings.vue
@@ -263,7 +263,7 @@ import UiButton from '@/components/core/ui/UiButton.vue';
 import {instanceInstallController} from '@/core/controllers/InstanceInstallController';
 import {resolveModloader, resolveModLoaderVersion, typeIdToProvider} from '@/utils/helpers/packHelpers';
 import CategorySelector from '@/components/core/modpack/create/CategorySelector.vue';
-import {computeAspectRatio, prettyByteFormat} from '@/utils';
+import {computeAspectRatio, prettyByteFormat, megabyteSize} from '@/utils';
 import UiToggle from '@/components/core/ui/UiToggle.vue';
 import ModloaderSelect from '@/components/core/modpack/components/ModloaderSelect.vue';
 import {ModLoaderWithPackId} from '@/core/@types/modpacks/modloaders';
@@ -301,8 +301,6 @@ export default class ModpackSettings extends Vue {
   
   instanceSettings: SaveJson = {} as any;
   previousSettings: SaveJson = {} as any;
-
-  megabyteSize = 1024 * 1024;
 
   showDuplicate = false;
   shareConfirm = false;

--- a/src/components/templates/modpack/ModpackSettings.vue
+++ b/src/components/templates/modpack/ModpackSettings.vue
@@ -193,7 +193,7 @@
       <small class="mb-4 block">This is for illustrative purposes only, this is not a complete example.</small>
 
       <code class="block bg-black rounded mb-6 px-2 py-2 overflow-x-auto select-text" v-if="instanceSettings.memory">
-        {{instanceSettings.shellArgs}} java -jar minecraft.jar -Xmx{{prettyByteFormat(Math.floor(parseInt(instanceSettings.memory.toString()) * 1024 * 1000))}} {{instanceSettings.jvmArgs}}
+        {{instanceSettings.shellArgs}} java -jar minecraft.jar -Xmx{{prettyByteFormat(Math.floor(parseInt(instanceSettings.memory.toString()) * megabyteSize))}} {{instanceSettings.jvmArgs}}
       </code>
     </div>
 
@@ -288,6 +288,7 @@ import KeyValueEditor from '@/components/core/modpack/components/KeyValueEditor.
     ShareInstanceModal,
   },
 })
+
 export default class ModpackSettings extends Vue {
   @State('settings') public settingsState!: SettingsState;
   @Getter('getActiveProfile', { namespace: 'core' }) public getActiveMcProfile!: any;
@@ -300,6 +301,8 @@ export default class ModpackSettings extends Vue {
   
   instanceSettings: SaveJson = {} as any;
   previousSettings: SaveJson = {} as any;
+
+  megabyteSize = 1024 * 1024;
 
   showDuplicate = false;
   shareConfirm = false;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -19,6 +19,11 @@ export async function safeNavigate(name: RouterNames, params?: any, query?: any)
   }
 }
 
+// Sizes of various byte amounts
+export const kilobyteSize: number = 1024;
+export const megabyteSize: number = 1024 * kilobyteSize;
+export const gigabyteSize: number = 1024 * megabyteSize;
+
 export const prettyByteFormat = (bytes: number) => {
   if (bytes === 0) return '0B';
 


### PR DESCRIPTION
This fixes an issue with the ram calculation in the "Startup preview" section of the modpack settings page. It was previously calculated as 1024 * 1000 when it should be 1024 * 1024. I have corrected this by adding some constants to the utils/helper.ts for kilobyte size, megabyte size, and gigabytes size. I used these values to correct the calculation issue seen on the settings page. I corrected a similar issue previously, but didn't catch this one. I fixed both using the same constants now to prevent duplicated constants in the code.