### PR TITLE
Hide titlebar and menubar when using system frame.

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -601,6 +601,7 @@ async function createPreLaunchWindow(source: string) {
     resizable: false,
     frame: false,
     titleBarStyle: 'hidden',
+    show: false,
     // Remove close button on mac
     closable: false,
     minimizable: false,
@@ -624,10 +625,12 @@ async function createPreLaunchWindow(source: string) {
     logger.debug("Loading app from built files")
     createProtocol(protocolSpace)
     await prelaunchWindow.loadURL(`${protocolSpace}://./prelaunch.html`);
-
-    // Try and force focus on the prelaunchWindow
-    prelaunchWindow.focus();
   }
+
+  prelaunchWindow.on("ready-to-show", () => {
+    // Try and force focus on the prelaunchWindow
+    prelaunchWindow?.show();
+  });
   
   prelaunchWindow.on('closed', () => {
     prelaunchWindow = null;
@@ -712,12 +715,22 @@ async function createWindow(reset = false) {
     height: 900,
     frame: useSystemFrame,
     titleBarStyle: useSystemFrame ? 'default' : 'hidden',
+    autoHideMenuBar: true,
+    show: false,
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false,
       disableBlinkFeatures: 'Auxclick',
       webSecurity: false,
     },
+  });
+
+  win.on('ready-to-show', async () => {
+    if (useSystemFrame) {
+      await win?.webContents.executeJavaScript("document.body.classList.add('system-frame')");
+    }
+    // Try and force focus on the window
+    win?.show();
   });
   
   win.webContents.setWindowOpenHandler((details) => {
@@ -752,9 +765,6 @@ async function createWindow(reset = false) {
     logger.debug("Loading app from built files")
     createProtocol(protocolSpace)
     await win.loadURL(`${protocolSpace}://./index.html`);
-    
-    // Try and force focus on the window
-    win.focus();
   }
 
   if (reset) {

--- a/src/background.ts
+++ b/src/background.ts
@@ -602,6 +602,7 @@ async function createPreLaunchWindow(source: string) {
     frame: false,
     titleBarStyle: 'hidden',
     show: false,
+    backgroundColor: '#151515',
     // Remove close button on mac
     closable: false,
     minimizable: false,
@@ -717,6 +718,7 @@ async function createWindow(reset = false) {
     titleBarStyle: useSystemFrame ? 'default' : 'hidden',
     autoHideMenuBar: true,
     show: false,
+    backgroundColor: '#2a2a2a',
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false,

--- a/src/components/layout/TitleBar.vue
+++ b/src/components/layout/TitleBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="titlebar" :class="{ isMac, isUnix }" @mousedown="startDragging" @dblclick="minMax" v-show="systemBarDisabled">
+  <div class="titlebar" :class="{ isMac, isUnix }" @mousedown="startDragging" @dblclick="minMax">
     <div class="spacer" v-if="isMac"></div>
     <div class="meta-title">
       <span>FTB App</span>
@@ -117,10 +117,6 @@ export default class TitleBar extends Vue {
     safeNavigate(RouterNames.SETTINGS_APP)
   }
   
-  get systemBarDisabled() {
-    return !this.settings?.settings?.appearance?.useSystemWindowStyle ?? false;
-  }
-  
   get isUnix() {
     return !platform.isOverwolf()
   }
@@ -140,6 +136,10 @@ export default class TitleBar extends Vue {
   z-index: 50000;
   position: relative;
   transition: background-color 0.3s ease-in-out;
+
+  .system-frame & {
+    display: none;
+  }
   
   &.blurred {
     background-color: var(--color-navbar);

--- a/src/views/MainApp.vue
+++ b/src/views/MainApp.vue
@@ -2,7 +2,7 @@
   <div id="app" class="theme-dark" :class="{'macos': isMac}">
     <title-bar />
     
-    <div class="app-container relative flex justify-center items-center h-full" v-if="!appReadyToGo">
+    <div class="app-container relative flex justify-center items-center" v-if="!appReadyToGo">
       <div class="text-center">
         <loader :title="status" sub-title="We're just getting some things ready... This shouldn't take long!" />
         
@@ -25,7 +25,7 @@
     </div>
     
     <!-- App has connected and is ready to use -->
-    <div class="app-container" v-if="appReadyToGo" :class="{'no-system-bar': systemBarDisabled}">
+    <div class="app-container" v-if="appReadyToGo">
       <main class="main">
         <sidebar v-if="showSidebar" />
         <div class="app-content relative">
@@ -431,11 +431,16 @@ export default class MainApp extends Vue {
 
 <style lang="scss" scoped>
 .app-container {
-  height: 100%;
+  height: calc(100% - 2rem);
   position: relative;
   
-  &.no-system-bar {
-    height: calc(100% - 2rem);
+  .macos & {
+    // Title bar on macos is 1.8rem not 2rem
+    height: calc(100% - 1.8rem);
+  }
+
+  .system-frame & {
+    height: 100%;
   }
 
   &.centered {
@@ -445,15 +450,6 @@ export default class MainApp extends Vue {
 
     .pushed-content {
       margin-top: -5rem;
-    }
-  }
-}
-
-#app.macos {
-  .app-container {
-    &.no-system-bar {
-      // Title bar on macos is 1.8rem not 2rem
-      height: calc(100% - 1.8rem);
     }
   }
 }
@@ -531,7 +527,7 @@ main.main {
 .debug {
   position: absolute;
   left: 1.5rem;
-  bottom: 3rem;
+  bottom: 1rem;
  
   .debug-item {
     color: rgba(white, .2);


### PR DESCRIPTION
Hide titlebar (in loading screen) and menubar when using system frame.

![Preview](https://github.com/FTBTeam/FTB-App/assets/17371317/5745abf2-b5dc-4259-a326-4b9095c5a6de)

Menu is not removed, only hidden, because hotkeys like Ctrl+Q to quit, will also be removed.

Also, I use backgroundColor and ready-to-show event to avoid visual flash. *[Electron documentation](https://www.electronjs.org/docs/latest/api/browser-window#showing-the-window-gracefully)*