### PR TITLE
Remove gap between titlebar and CloseablePanel when using system frame.

### DIFF
--- a/src/components/molecules/ClosablePanel.vue
+++ b/src/components/molecules/ClosablePanel.vue
@@ -77,8 +77,8 @@ export default class ClosablePanel extends Vue {
 <style scoped lang="scss">
 .closable-panel {
   position: fixed;
-  height: calc(100% - 1.8rem);
   top: 2rem; // windows + linux title bar?
+  bottom: 0;
   left: 0;
 
   display: flex;
@@ -96,7 +96,11 @@ export default class ClosablePanel extends Vue {
   &.is-mac {
     top: 1.8rem;
   }
-  
+
+  .system-frame & {
+    top: 0;
+  }
+
   .panel-container {
     background-color: var(--color-navbar);
     width: 95%;


### PR DESCRIPTION
Remove the gap as shown in screenshot below.

![image](https://github.com/FTBTeam/FTB-App/assets/17371317/0b263aa2-1807-4335-8d74-f2a02a813205)
