### PR TITLE
make stale workflow look for the right label [-skip release] [-skip overwolf]

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
           days-before-close: 3
           days-before-pr-close: -1
           stale-issue-label: "status: stale"
-          only-issue-labels: 'Awaiting Response'
-          exempt-issue-labels: "status: confirmed, status: investigate, feature:request,fixed/release,fixed/dev,status: planned,question/discussion,priority/high,priority/medium,priority/low"
+          only-issue-labels: 'Awaiting Reply'
+          exempt-issue-labels: "Blocked,status: confirmed,status: investigate,fixed/release,fixed/dev,status: planned,priority/high,priority/medium,priority/low"
           exempt-all-assignees: true
           exempt-all-milestones: true


### PR DESCRIPTION
this fixes issues in awaiting reply not being marked as stale after more then 7 days